### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "creativestyle/magesuite-gdpr": "^1.0.1",
     "creativestyle/magesuite-sorting": "^1.0.0",
     "creativestyle/theme-creativeshop": "^8.0.0",
-    "smile/elasticsuite": "2.8.*"
+    "smile/elasticsuite": "2.9.*"
   }
 }
 


### PR DESCRIPTION
Due to the introduction of Elasticsearch 7 support and the recurrent changes they made on GraphQL implementation in Magento 2.3.5, we cannot ensure compatibility between ElasticSuite <2.9 and Magento >=2.3.5 versions.

If your project is based on Magento >= 2.3.5, you can start working with ElasticSuite today using the latest 2.9.x release.